### PR TITLE
fix for rails 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ Cool Toys
 
 Here are a few quick examples of things you can easily tweak.
 
-##localize column headers
+## localize column headers
 
 ```ruby
-#app/admin/posts.rb
+# app/admin/posts.rb
 ActiveAdmin.register Post do
   config.xls_builder.i18n_scope = [:active_record, :models, :posts]
 end
 ```
 
-##Use blocks for adding computed fields
+## Use blocks for adding computed fields
 
 ```ruby
-#app/admin/posts.rb
+# app/admin/posts.rb
 ActiveAdmin.register Post do
   config.xls_builder.column('author_name') do |resource|
     resource.author.name
@@ -56,26 +56,26 @@ ActiveAdmin.register Post do
 end
 ```
 
-##Change the column header format
+## Change the column header format
 
 ```ruby
-#app/admin/posts.rb
+# app/admin/posts.rb
 ActiveAdmin.register Post do
   config.xls_builder.header_format = { :weight => :bold,
                                        :color => :blue }
 end
 ```
 
-##Remove columns
+## Remove columns
 
 ```ruby
-#app/admin/posts.rb
+# app/admin/posts.rb
 ActiveAdmin.register Post do
   config.xls_builder.delete_columns :id, :created_at, :updated_at
 end
 ```
 
-#Using the DSL
+# Using the DSL
 
 Everything that you do with the config's default builder can be done via
 the resource DSL.
@@ -114,7 +114,7 @@ ActiveAdmin.register Post do
 end
 ```
 
-#Specs
+# Specs
 ------
 Running specs for this gem requires that you construct a rails application.
 To execute the specs, navigate to the gem directory,
@@ -128,7 +128,7 @@ bundle exec rake setup
 bundle exec rake
 ```
 
-#Copyright and License
+# Copyright and License
 ----------
 
 activeadmin-xls &copy; 2014 by [Todd Hambley](mailto:thambley@travelleaders.com).

--- a/lib/active_admin/xls/engine.rb
+++ b/lib/active_admin/xls/engine.rb
@@ -12,7 +12,7 @@ module ActiveAdmin
 
         ActiveAdmin::ResourceDSL.send :include, ActiveAdmin::Xls::DSL
         ActiveAdmin::Resource.send :include, ActiveAdmin::Xls::ResourceExtension
-        ActiveAdmin::ResourceController.send :include, ActiveAdmin::Xls::ResourceControllerExtension
+        ActiveAdmin::ResourceController.send :prepend, ActiveAdmin::Xls::ResourceControllerExtension
       end
     end
   end

--- a/lib/active_admin/xls/resource_controller_extension.rb
+++ b/lib/active_admin/xls/resource_controller_extension.rb
@@ -1,14 +1,12 @@
 module ActiveAdmin
   module Xls
     module ResourceControllerExtension
-      def self.included(base)
-        base.send :alias_method_chain, :per_page, :xls
-        base.send :alias_method_chain, :index, :xls
+      def self.prepended(base)
         base.send :respond_to, :xls
       end
 
-      def index_with_xls(&block)
-        index_without_xls do |format|
+      def index(&block)
+        super do |format|
           block.call format if block_given?
 
           format.xls do
@@ -21,12 +19,12 @@ module ActiveAdmin
       end
 
       # patching per_page to use the CSV record max for pagination when the format is xls
-      def per_page_with_xls
+      def per_page
         if request.format ==  Mime::Type.lookup_by_extension(:xls)
           return respond_to?(:max_per_page, true) ? max_per_page : active_admin_config.max_per_page
         end
 
-        per_page_without_xls
+        super
       end
 
       # Returns a filename for the xls file using the collection_name


### PR DESCRIPTION
* fix for:
`DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead.`
* fix README typo